### PR TITLE
[IMP][15.0] to_backend_theme: removing the margin causes inconsistency in the layout

### DIFF
--- a/to_backend_theme/static/src/scss/style.scss
+++ b/to_backend_theme/static/src/scss/style.scss
@@ -93,7 +93,6 @@ body {
 	.o_list_view,
 	.o_settings_container .o_setting_box {
 		.custom-checkbox:not(.o_boolean_toggle) {
-			margin-right: auto;
 			top: auto;
 			.custom-control-label {
 				top: auto;


### PR DESCRIPTION
Hiện tại, khi vào setting, checkbox và label đang bị lệch nhau do `margin-right` của checkbox được ưu tiên.

Video:

https://user-images.githubusercontent.com/90305443/174708500-acaeaa8c-8ca7-4959-9054-b22c962273c2.mp4

PR này sẽ bỏ đi `margin-right` của checkbox để label và checkbox gần nhau hơn và không bị lệch giao diện khi đọc từ trái sang phải.

List view không bị ảnh hưởng sau khi bỏ `margin-right`:



https://user-images.githubusercontent.com/90305443/174709692-1c857f50-ba29-4ffb-bc4c-8e01b84b55af.mp4



