### PR TITLE
[FIX][15.0] to_backend_theme: Fix `pad` UI goes wrong

### DIFF
--- a/to_backend_theme/static/src/scss/style.scss
+++ b/to_backend_theme/static/src/scss/style.scss
@@ -70,12 +70,33 @@ body {
 	}
 }
 
+// Avoid avatar image stretch
 .o_Follower{
     a{
         .o_Follower_avatar{
             object-fit: cover;
         }
     }
+}
+
+// Fix `pad` UI
+.o_note_form_view.o_form_view {
+    .o_form_sheet_bg {
+        // Odoo try to set a child height with true value (500px) but the correctly way is set true value for parent-flex
+        // currently Odoo set .oe_pad .oe_pad_content.oe_editing {height:500px; ...}
+        height: 500px;
+        .o_form_sheet {
+            .oe_pad {
+                .oe_pad_content {
+                    display: flex;
+                }
+            }    
+        }
+    }
+}
+.oe_pad .oe_pad_content.oe_editing{
+    display: flex;
+    flex: 1;
 }
 
 .o_control_panel {


### PR DESCRIPTION
Ticket: https://viindoo.com/web#cids=1&id=7192&model=helpdesk.ticket

-Hiện tại khi mở Note trên Chrome sẽ bị gặp lỗi hiển thị phần edit của `pad` bị co vào quá nhiều dẫn đến người dùng không thể nhìn được nội dung khi edit
_Before_

![Screenshot from 2022-07-11 13-34-05](https://user-images.githubusercontent.com/90305443/178204355-2fc03be2-ba40-4ec1-9b33-1d60c573eac2.png)

Nhưng tình trạng này lại không bị khi mở bằng Firefox, Safari.

Việc này có được đề cập tại đây: https://bugs.chromium.org/p/chromium/issues/detail?id=428049#c11

> Gecko is *always* resolving percentages regardless of the flex-basis.
Chrome is *never* resolving percentages, regardless of the flex-basis.


Chrome và Firefox không cùng engine nên việc render `flex-basis` sẽ dẫn đến khác nhau. 

Để xử lí vấn đề này, PR này sẽ gắn giá trị tuyệt đối cho `flex-parent` và các `flex-container` nằm trong `flex-parent` sẽ cần có thêm `display:flex, flex:1` để chúng có thể co dãn cùng với kích thước của flex-parent.


_After_

![Screenshot from 2022-07-11 13-33-20](https://user-images.githubusercontent.com/90305443/178208050-4b31fe17-34ec-4875-aab0-0b4485ed0e68.png)

PR này sẽ chỉ fix cho repo của mình mà không fix cho Odoo vì từ bản 16 Odoo đã bỏ `pad`:

- `https://github.com/odoo/odoo/pull/75768` : PR này Odoo cải tiến cho edit collab ở bất kỳ chỗ nào có html field
- `https://github.com/odoo/odoo/pull/76467` : PR này Odoo xoá pad 