### PR TITLE
[MISC][16.0] to_backend_theme: missing set auto_install to False

### DIFF
--- a/to_backend_theme/__manifest__.py
+++ b/to_backend_theme/__manifest__.py
@@ -46,7 +46,7 @@ Backend theme for Viindoo, based on the Openworx Backend Theme
         },
     'installable': False, #Set True when upgrading to 16.0
     'application': False,
-    'auto_install': ['web'],
+    'auto_install': False, # Set this as ['web'] after upgrading for v16
     'price': 99.9,
     'currency': 'EUR',
     'license': 'LGPL-3',


### PR DESCRIPTION
-This might cause runbot error on v16
Ref: ticket https://viindoo.com/web?debug=1#id=18912&menu_id=89&model=helpdesk.ticket&view_type=form