### PR TITLE
[FIX] [16.0] web_responsive: active default menu app

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.esm.js
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.esm.js
@@ -22,7 +22,17 @@ patch(WebClient.prototype, "web_responsive.DefaultAppsMenu", {
         this._super();
         useBus(this.env.bus, "APPS_MENU:STATE_CHANGED", ({detail: state}) => {
             document.body.classList.toggle("o_apps_menu_opened", state);
+            document.body.classList.toggle("o_first_app", false);
         });
+    },
+    _loadDefaultApp() {
+        var menu_apps_dropdown = document.querySelector(
+            ".o_navbar_apps_menu .dropdown-toggle"
+        );
+        menu_apps_dropdown.click();
+        document.body.classList.toggle("o_apps_menu_opened", true);
+        document.body.classList.toggle("o_first_app", true);
+        return true;
     },
 });
 

--- a/web_responsive/static/src/components/apps_menu/apps_menu.scss
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.scss
@@ -14,6 +14,12 @@
     left: 0 !important;
 }
 
+// We can't use display: none here because of tests
+.o_first_app .o_navbar_apps_menu .dropdown-toggle {
+    z-index: -1;
+    cursor: default;
+}
+
 .o_apps_menu_opened .o_main_navbar {
     .o_menu_brand,
     .o_menu_sections {


### PR DESCRIPTION
This Pr: xử lý vấn đề khi nâng cấp viin_website 
- truy cập web, web#home sẻ hiển thị  menu app của viindoo thay vì chuyển hướng sang Discuss
- click home menu trên Website mở trực tiếp  menu app của viindoo, không cần phải chuyển hướng sang ../web#home - hiện tại vẫn hiển thị menu app song tự động chuyển về discuss
- video trước khi sửa:

[Untitled_ Jun 1, 2023 10_22 AM.webm](https://github.com/Viindoo/backend_theme/assets/71593331/c381d0ee-c068-4195-848f-af60e61ffdd4)

-video sau khi sửa:

[Untitled_ May 31, 2023 9_15 AM.webm](https://github.com/Viindoo/backend_theme/assets/71593331/affb72bd-aa13-4645-b8f4-ffdc6e07c37f)
