### PR TITLE
[IMP][14.0] web_responsive: Adjust app icon size

### DIFF
--- a/web_responsive/static/src/scss/web_responsive.scss
+++ b/web_responsive/static/src/scss/web_responsive.scss
@@ -229,8 +229,8 @@ $chatter_zone_width: 35%;
         }
 
         .o-app-icon {
-            height: auto;
-            max-width: 6rem;
+            width: 70px;
+            height: 70px;
         }
 
         .o-app-name {


### PR DESCRIPTION
Ticket: [Điều chỉnh Icon app](https://viindoo.com/web#id=51912&cids=1&menu_id=777&action=1074&active_id=6&model=viin.helpdesk.ticket&view_type=form)

- Currently the css of the app icon is following the font, making the app icon larger than expected
- Handling css is similar to odoo
<img width="1431" alt="Screenshot 2024-04-06 at 2 43 29 PM" src="https://github.com/Viindoo/backend_theme/assets/41675989/fd298325-c8b1-4324-97cd-8c6535661c45">


<img width="399" alt="Screenshot 2024-04-06 at 2 44 42 PM" src="https://github.com/Viindoo/backend_theme/assets/41675989/3ff44144-7a9e-4ed4-a950-ce3282525d04">

